### PR TITLE
fix(ci): test on Node 22/24 and drop EOL Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20', '22']
+        node-version: ['22', '24']
 
     steps:
       - name: Checkout code
@@ -37,11 +37,11 @@ jobs:
         run: npm test
 
       - name: Run tests with coverage
-        if: matrix.node-version == 20
+        if: matrix.node-version == 22
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        if: matrix.node-version == 20
+        if: matrix.node-version == 22
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage/coverage-final.json
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           
       # Ensure npm 11.5.1 or later is installed

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/thevgergroup/apollo-io-mcp#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.19.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Problem

Every PR (including all dependabot updates) fails CI on the Test (20) job:

```
TypeError: webidl.util.markAsUncloneable is not a function
    at new CacheStorage (.../undici/lib/web/cache/cachestorage.js:20:17)
```

Root cause: `undici` 8.x dropped Node.js 20 support (requires `node >= 22.19.0` per its engines), and Node 20 is EOL since April 2026. The app imports undici at module load, so the CLI crashes instantly under Node 20. This has blocked CI on main since the undici 8.9.0 bump (#110) and is blocking the remaining open dependabot PR (#117).

## Changes

- Test matrix: `['20', '22']` -> `['22', '24']` (Node 22 and 24 LTS)
- Coverage/Codecov runs on the `22` matrix entry
- `lint`, `security`, `integration`, `publish`, and `security.yml` jobs use Node 22
- `package.json` engines: `>=20.0.0` -> `>=22.19.0` to match undici 8.x requirement

Verified: Test (22) already passes on the affected PRs; this change removes the failing Node 20 leg so CI goes green.